### PR TITLE
Refactor to use helper functions and apply clippy fixes

### DIFF
--- a/cli/src/commands/model/metadata.rs
+++ b/cli/src/commands/model/metadata.rs
@@ -7,20 +7,20 @@ pub async fn metadata(
     api_base_url: &str,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     let client = Client::new();
-    let url = format!("{}/api/models/{}", api_base_url, repository);
+    let url = build_metadata_url(repository, api_base_url);
     let response = client.get(&url).send().await?;
     if response.status().is_success() {
         let metadata: Value = response.json().await?;
-        println!("{}", metadata.to_string());
+        println!("{metadata}");
         Ok(())
     } else {
         eprintln!("Failed to fetch metadata: {}", response.status());
-        Err(format!("Failed to get metadata for {}", repository).into())
+        Err(format!("Failed to get metadata for {repository}").into())
     }
 }
 
 pub fn build_metadata_url(repository: &str, api_base_url: &str) -> String {
-    format!("{}/api/models/{}", api_base_url, repository)
+    format!("{api_base_url}/api/models/{repository}")
 }
 
 #[cfg(test)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -92,7 +92,7 @@ async fn model_command(
             if let Some(rev) = revision {
                 // Convert to a string to append revision
                 let lds = local_dir.to_string_lossy();
-                local_dir = std::path::PathBuf::from(format!("{}:{}", lds, rev));
+                local_dir = std::path::PathBuf::from(format!("{lds}:{rev}"));
             }
             commands::model::download(
                 repository,


### PR DESCRIPTION
## Summary
This PR refactors the codebase to use the helper functions we created in the testing PR, eliminating code duplication and applying modern Rust best practices.

## Refactoring Changes
- **search.rs**: Now uses `build_search_url()` instead of manual URL construction
- **metadata.rs**: Now uses `build_metadata_url()` instead of format macro
- **revisions.rs**: Now uses `build_revisions_url()` instead of format macro  
- **download.rs**: Now uses `build_file_list_url()`, `build_download_url()`, and `should_ignore_file()`
- **Move test utility**: `parse_branches_from_json()` moved to test module where it belongs

## Code Quality Improvements
- **Applied 19 clippy fixes** for modern Rust practices:
  - Use inline format strings (`{variable}` instead of `"{}", variable`)
  - Remove unnecessary borrows (`to` instead of `&to`)
  - Improve function signatures (`&[String]` instead of `&Vec<String>`)
  - Remove unnecessary `.to_string()` calls
- **Eliminated all compiler warnings**: From 7 warnings to 0
- **Clean formatting**: Applied `cargo fmt` throughout

## Results
- ✅ **All 35 tests pass** (29 unit + 6 integration)
- ✅ **Zero clippy warnings** - pristine lint
- ✅ **Zero compiler warnings** - clean build
- ✅ **Maintains full functionality** with better code quality
- ✅ **DRY principle applied** - no more duplicated URL construction logic

## Files Changed
- `cli/src/main.rs` - Modern format strings
- `cli/src/commands/model/search.rs` - Use helper function + clippy fixes
- `cli/src/commands/model/metadata.rs` - Use helper function + clippy fixes  
- `cli/src/commands/model/revisions.rs` - Use helper function + clippy fixes
- `cli/src/commands/model/download.rs` - Use helper functions + clippy fixes

This refactoring resolves the "unused function" warnings from the previous PR by actually using the helper functions throughout the codebase, resulting in cleaner, more maintainable code.

🤖 Generated with [Claude Code](https://claude.ai/code)